### PR TITLE
Quote paths to work with paths including spaces

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,9 @@ resource "null_resource" "buildlambdazip" {
   triggers { key = "${uuid()}" }
   provisioner "local-exec" {
     command = <<EOF
-    mkdir -p ${path.module}/lambda && mkdir -p ${path.module}/tmp
-    cp ${path.module}/ebs_bckup/ebs_bckup.py ${path.module}/tmp/ebs_bckup.py
-    echo "${data.template_file.vars.rendered}" > ${path.module}/tmp/vars.ini
+    mkdir -p "${path.module}/lambda" && mkdir -p "${path.module}/tmp"
+    cp "${path.module}/ebs_bckup/ebs_bckup.py" "${path.module}/tmp/ebs_bckup.py"
+    echo "${data.template_file.vars.rendered}" > "${path.module}/tmp/vars.ini"
 EOF
   }
 }


### PR DESCRIPTION
This fixes the errors when running the Terraform from a file path containing spaces